### PR TITLE
Fix React-port launch regression by preserving aim power until release

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -254,8 +254,12 @@ function drawBalls() {
           if (ball.clicked) ball.aim();
         } else {
           if (ball.onBall(mouseX, mouseY)) ball.hover();
-          ball.xPower = 0;
-          ball.yPower = 0;
+          // Keep power values intact until mouseReleased runs so launch
+          // strength cannot be cleared before force is applied.
+          if (!ball.clicked) {
+            ball.xPower = 0;
+            ball.yPower = 0;
+          }
         }
       }
     });
@@ -465,6 +469,11 @@ function mouseReleased() {
         ball.launched();
         totalShots++;
       }
+
+      // Release should always end the aiming session for this ball.
+      ball.clicked = false;
+      ball.xPower = 0;
+      ball.yPower = 0;
     });
     return false;
   }


### PR DESCRIPTION
### Motivation

- The React port exhibited a launch regression where a ball's aim power could be cleared in the draw loop before `mouseReleased()` applied the launch force, causing clicks/drags to sometimes not launch.

### Description

- Updated `sketch.js` to preserve `xPower`/`yPower` during the draw cycle by only clearing them when a ball is not in an active `clicked` state (in `drawBalls()`).
- Ensured `mouseReleased()` applies force using the preserved power and then always ends the aiming session by resetting `clicked`, `xPower`, and `yPower` for each ball.
- The change avoids losing launch strength mid-interaction so that `Matter.Body.applyForce` receives the intended vector when called.

### Testing

- Started a local static server with `python3 -m http.server 8000` and verified the app served successfully. 
- Ran a headless browser smoke test with Playwright that performed a drag/release interaction and saved a screenshot, and observed the app load and respond to the interaction (screenshot captured). 
- The automated JS state check used in the smoke test did not find the inspected variable in that run, so programmatic verification of launch via `window` inspection failed while the screenshot shows the page rendered; further end-to-end assertions may be added if needed. 
- Confirmed the change is limited to `sketch.js` and no other runtime changes were introduced during the fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a33d23b7c483228c10f5221ae0fadf)