### PR TITLE
Fix asset paths in React copy so images and metadata load

### DIFF
--- a/react site/imageBall.js
+++ b/react site/imageBall.js
@@ -35,7 +35,7 @@ class ImageBall {
     this.body.label = 'Image Ball';
 
     // Image source URL — used by React detail panel
-    this.imageSrc = itemName ? `assets/images/${itemName}.jpg` : '';
+    this.imageSrc = itemName ? `../assets/images/${itemName}.jpg` : '';
 
     this.fullImage = img;
     const minSize = Math.min(img.height, img.width);

--- a/react site/index.html
+++ b/react site/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="user-scalable=no,initial-scale=1,maximum-scale=1,minimum-scale=1,width=device-width">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">
-    <link rel="shortcut icon" href="assets/images/favicon.png">
+    <link rel="shortcut icon" href="../assets/images/favicon.png">
     <link rel="stylesheet" href="main.css">
 
     <!-- ✅ FIX: Use pinned CDN URLs instead of broken ../assets/ relative paths -->

--- a/react site/sketch.js
+++ b/react site/sketch.js
@@ -68,8 +68,8 @@ const config = {
 
 function preload() {
   for (const item of config.itemsToDisplay) {
-    imgs.push(loadImage(`assets/images/${item}.jpg`));
-    pageInfo.push(loadStrings(`assets/${item}.txt`));
+    imgs.push(loadImage(`../assets/images/${item}.jpg`));
+    pageInfo.push(loadStrings(`../assets/${item}.txt`));
   }
 }
 


### PR DESCRIPTION
### Motivation
- The React copy of the site was requesting assets relative to the `react site/` folder, which produced 404s for images and metadata and prevented normal ball behavior (preload failures). 
- The change aims to point the React-hosted pages at the shared `assets/` directory so the p5 sketch can load images/text and the React detail panel can display images.

### Description
- Update `react site/sketch.js` `preload()` to load images and text from `../assets/...` so requests resolve to the repository-level `assets/` directory. 
- Update `react site/imageBall.js` to set the detail-panel `imageSrc` to `../assets/images/...` so React's detail view references valid image files. 
- Update `react site/index.html` favicon path to `../assets/images/favicon.png` to avoid a missing resource when the page is served from `/react site/`.

### Testing
- Launched a local static server with `python3 -m http.server 4173 --directory /workspace/WebsiteAnimation` and served the React page. 
- Automated a browser interaction using Playwright to load `http://127.0.0.1:4173/react%20site/index.html`, perform a drag/launch interaction, and capture a screenshot. 
- Observed asset requests return `200` (no 404s) and the interaction produced the expected canvas behavior; only an in-browser Babel warning remained (expected for runtime JSX transform).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a33d23b7c483228c10f5221ae0fadf)