### PR TITLE
Fix GA4 worker CORS to support apex + www origins

### DIFF
--- a/ga4-worker/ga4-worker.js
+++ b/ga4-worker/ga4-worker.js
@@ -14,7 +14,7 @@ export default {
   async fetch(request, env) {
     // CORS preflight
     if (request.method === 'OPTIONS') {
-      return new Response(null, { headers: corsHeaders(env) });
+      return new Response(null, { headers: corsHeaders(env, request) });
     }
 
     try {
@@ -42,24 +42,46 @@ export default {
       });
 
       return new Response(body, {
-        headers: { 'Content-Type': 'application/json', ...corsHeaders(env) },
+        headers: { 'Content-Type': 'application/json', ...corsHeaders(env, request) },
       });
     } catch (err) {
       return new Response(
         JSON.stringify({ error: err.message }),
-        { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders(env) } },
+        { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders(env, request) } },
       );
     }
   },
 };
 
-function corsHeaders(env) {
+function corsHeaders(env, request) {
+  const requestOrigin = request.headers.get('Origin');
+  const allowList = parseAllowedOrigins(env);
+
+  const allowOrigin = requestOrigin && allowList.includes(requestOrigin)
+    ? requestOrigin
+    : allowList[0] || '*';
+
   return {
-    'Access-Control-Allow-Origin': env.ALLOWED_ORIGIN || '*',
+    'Access-Control-Allow-Origin': allowOrigin,
     'Access-Control-Allow-Methods': 'GET, OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type',
     'Access-Control-Max-Age': '86400',
+    'Vary': 'Origin',
   };
+}
+
+function parseAllowedOrigins(env) {
+  if (env.ALLOWED_ORIGINS) {
+    return env.ALLOWED_ORIGINS
+      .split(',')
+      .map((origin) => origin.trim())
+      .filter(Boolean);
+  }
+
+  if (env.ALLOWED_ORIGIN) return [env.ALLOWED_ORIGIN];
+
+  // Safe defaults for this project.
+  return ['https://dadatadad.com', 'https://www.dadatadad.com'];
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/ga4-worker/wrangler.toml
+++ b/ga4-worker/wrangler.toml
@@ -5,4 +5,5 @@ compatibility_date = "2024-01-01"
 # Set these via: npx wrangler secret put <NAME>
 # GA4_SERVICE_ACCOUNT_JSON — paste the entire JSON key file contents
 # GA4_PROPERTY_ID          — numeric property ID from GA4 Admin → Property Settings
-# ALLOWED_ORIGIN           — "https://dadatadad.com"
+# ALLOWED_ORIGINS          — comma-separated, e.g. "https://dadatadad.com,https://www.dadatadad.com"
+# ALLOWED_ORIGIN           — legacy single origin (still supported)


### PR DESCRIPTION
### Motivation
- The analytics dashboard on `www.dadatadad.com` could be blocked from fetching live GA4 data because the Cloudflare worker only reflected a single allowed origin, causing the dashboard to appear non-live.
- Make the worker accept requests from both apex and `www` origins and provide a safe, configurable fallback so the dashboard reliably receives data.

### Description
- Updated `ga4-worker/ga4-worker.js` to compute CORS headers from the incoming `Origin` header and pass the `request` into `corsHeaders` for preflight, success, and error responses. 
- Added `parseAllowedOrigins` which supports a new comma-separated `ALLOWED_ORIGINS` env var while remaining compatible with legacy `ALLOWED_ORIGIN`, and added a default allow-list fallback for the project. 
- Echo the accepted origin dynamically and return `Vary: Origin` so browsers and caches handle responses correctly. 
- Updated `ga4-worker/wrangler.toml` comments to document `ALLOWED_ORIGINS` and the legacy `ALLOWED_ORIGIN` option.

### Testing
- Ran a production build with `npm run build` (Vite) which completed successfully (build finished with chunk-size warnings only). 
- Attempted to fetch the deployed worker with `curl 'https://ga4-analytics-api.dadatadad-analytics.workers.dev?days=30'` from this environment which returned a `403`/proxy error so the live endpoint could not be validated here. 
- Committed the changes and prepared the PR; recommend deploying the worker and setting `ALLOWED_ORIGINS="https://dadatadad.com,https://www.dadatadad.com"` before re-testing the dashboard in-browser.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a73b5e8e6083229e2f352d09367c82)