### PR TITLE
Fix CSP blocking bundled script execution

### DIFF
--- a/dist/.htaccess
+++ b/dist/.htaccess
@@ -42,7 +42,7 @@ RewriteRule ^(.*)$ https://dadatadad.com/$1 [L,R=301]
   # Google Analytics, Google Fonts, and your own assets.
   Header always set Content-Security-Policy "\
     default-src 'self'; \
-    script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; \
+    script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com; \
     style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; \
     font-src 'self' https://fonts.gstatic.com; \
     img-src 'self' data: https://www.google-analytics.com https://www.googletagmanager.com; \


### PR DESCRIPTION
### Motivation
- A recent stricter Content-Security-Policy in `dist/.htaccess` caused the site to render blank with an `EvalError` because the production bundle performs eval-style execution in at least one dependency path. 
- The change restores compatibility so the client bundle can run while keeping other CSP directives intact.

### Description
- Modified `dist/.htaccess` to add `'unsafe-eval'` to the `script-src` directive in the `Content-Security-Policy` header. 
- No other security headers or sources were changed; this is a minimal compatibility fix for the deployed policy.

### Testing
- Ran `npm run build` which completed successfully. 
- Verified the updated header presence with `nl -ba dist/.htaccess | sed -n '38,52p'`, confirming the `script-src` line now includes `'unsafe-eval'`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a780e819448322b3ed66dcaa70f4a9)