### PR TITLE
fix: add missing scoreGoal() method and fix openDetail() counter

### DIFF
--- a/src/game/Ball.js
+++ b/src/game/Ball.js
@@ -82,9 +82,13 @@ export default class Ball {
 
   openDetail() {
     if (this.pageOpen) return null;
-    this.makes++;
+    this.opens++;
     this.pageOpen = true;
     return this.getDetailData();
+  }
+
+  scoreGoal() {
+    this.makes++;
   }
 
   closeDetail() { this.pageOpen = false; }


### PR DESCRIPTION
ball.scoreGoal() was called in the collision handler but never defined in Ball.js, causing a TypeError that prevented goal detail views from opening and balls from resetting. Also fixed openDetail() to increment opens instead of makes, since makes is now tracked separately by scoreGoal().