### PR TITLE
Track CTA clicks in GA4 bridge

### DIFF
--- a/src/game/ga4.js
+++ b/src/game/ga4.js
@@ -9,6 +9,7 @@
  *   ball_score      — ball collides with matching goal → detail opens
  *   detail_open     — project detail modal displayed
  *   detail_close    — modal dismissed
+ *   cta_click       — user clicks the CTA link in the detail modal
  *   portfolio_loaded — all images loaded, canvas ready
  */
 
@@ -83,6 +84,17 @@ export function initGA4Tracking() {
   unsubs.push(
     bus.on('detail:close', () => {
       track('detail_close');
+    }),
+  );
+
+  // CTA clicked from detail modal
+  unsubs.push(
+    bus.on('cta:click', ({ name, link, category }) => {
+      track('cta_click', {
+        project_name: name || 'unknown',
+        project_link: link || '',
+        project_category: category || '',
+      });
     }),
   );
 


### PR DESCRIPTION
### Motivation
- Ensure CTA clicks emitted by the detail modal (`cta:click`) are forwarded to GA4 so CTA metrics populate in analytics and the dashboard.

### Description
- Add a `bus.on('cta:click', ...)` listener in `initGA4Tracking()` (`src/game/ga4.js`) that sends a `cta_click` event with `project_name`, `project_link`, and `project_category`, and update the file header to document `cta_click`.

### Testing
- Ran `npm run build` and the Vite production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a875a61f2083229d9b283a6ac0fc5e)