### PR TITLE
Fix Firefox ball image rendering fallback

### DIFF
--- a/src/game/Ball.js
+++ b/src/game/Ball.js
@@ -160,14 +160,36 @@ export default class Ball {
     octx.arc(cssSize / 2, cssSize / 2, cssSize / 2, 0, Math.PI * 2);
     octx.clip();
 
-    // Draw from full-res source with square crop
-    const srcCanvas = this.fullImage.canvas || this.fullImage.drawingContext?.canvas;
-    if (srcCanvas) {
-      octx.drawImage(
-        srcCanvas,
-        this._cropX, this._cropY, this._cropSize, this._cropSize,
-        0, 0, cssSize, cssSize,
-      );
+    // Draw from full-res source with square crop.
+    // Firefox can differ in which p5 image backing element is exposed,
+    // so we check all common sources and gracefully fall back.
+    const srcEl =
+      this.fullImage?.canvas ||
+      this.fullImage?.drawingContext?.canvas ||
+      this.fullImage?.elt ||
+      this.fullImage;
+
+    if (srcEl) {
+      try {
+        octx.drawImage(
+          srcEl,
+          this._cropX, this._cropY, this._cropSize, this._cropSize,
+          0, 0, cssSize, cssSize,
+        );
+        return;
+      } catch (_) {
+        // Fallback below
+      }
+    }
+
+    // Last-resort fallback: draw already-cropped p5 image backing canvas.
+    const fallbackEl =
+      this.ballImage?.canvas ||
+      this.ballImage?.drawingContext?.canvas ||
+      this.ballImage?.elt ||
+      this.ballImage;
+    if (fallbackEl) {
+      octx.drawImage(fallbackEl, 0, 0, cssSize, cssSize);
     }
   }
 


### PR DESCRIPTION
### Motivation
- Firefox can expose p5 image internals differently than Chromium, causing the offscreen `drawImage` path to fail and leaving balls visually empty; this change ensures robust image drawing across browsers.

### Description
- Updated `_renderCircleImage` in `src/game/Ball.js` to probe multiple possible p5 backing elements (`fullImage?.canvas`, `fullImage?.drawingContext?.canvas`, `fullImage?.elt`, and `fullImage`) before drawing.
- Wrapped the primary `drawImage` call in a `try/catch` so an incompatible source won't abort rendering and will fall through to fallback logic.
- Added a last-resort fallback that renders from the already-cropped `ballImage` backing element (`ballImage?.canvas`, `ballImage?.drawingContext?.canvas`, `ballImage?.elt`, or `ballImage`) to avoid blank balls when the full-res source is not usable.

### Testing
- Ran `npm run build` and the build completed successfully (production bundles generated).
- Launched the dev server with `npm run dev` as a sanity check and the server started successfully.
- Automated visual check via a Playwright script that loaded `http://127.0.0.1:4173/` and captured a screenshot, confirming the homepage rendered without blank ball images.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa2ee0f9a083228debf8c9f0334099)