### PR TITLE
Restore internal analytics dashboard link in project modal

### DIFF
--- a/src/components/DetailModal.jsx
+++ b/src/components/DetailModal.jsx
@@ -17,7 +17,12 @@ import config from '../game/config.js';
 import bus from '../game/EventBus.js';
 
 function isSafeUrl(url) {
-  try { return ['http:', 'https:', 'mailto:'].includes(new URL(url).protocol); }
+  try {
+    const parsed = new URL(url, window.location.origin);
+    if (parsed.protocol === 'mailto:') return true;
+    if (!['http:', 'https:'].includes(parsed.protocol)) return false;
+    return parsed.origin === window.location.origin || /^https?:\/\//.test(url);
+  }
   catch { return false; }
 }
 


### PR DESCRIPTION
### Motivation
- The project detail modal hid the CTA for the internal analytics dashboard because the tightened URL validator rejected relative/same-origin links.

### Description
- Updated `isSafeUrl` in `src/components/DetailModal.jsx` to parse URLs with `window.location.origin` as the base so relative paths (e.g. `/analytics-v3.html`) are accepted.
- Kept protocol restrictions by allowing only `mailto:`, `http:`, and `https:` and explicitly permitting same-origin URLs while still rejecting other schemes.
- No behavioral changes to external links or CTA tracking were made; only the safety check was adjusted.

### Testing
- Ran `npm run build` successfully to verify the app bundles cleanly.
- Launched the dev server (`npm run dev`) and inspected the UI to confirm the modal now shows the internal dashboard CTA.
- Executed a Playwright script to open the page, trigger a modal, and capture a screenshot which shows the CTA rendering as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab2eef76f883228c19066fb7c20888)