### PR TITLE
fix: add per-day ctaClicks to time series for line chart

### DIFF
--- a/ga4-worker/ga4-worker.js
+++ b/ga4-worker/ga4-worker.js
@@ -195,25 +195,44 @@ async function fetchTimeSeries(token, propId, days) {
     limit: days + 1,
   });
 
-  // Also fetch ball_launch event counts per day for interaction rate
-  const ballReport = await runReport(token, propId, {
-    dateRanges: [{ startDate: `${days}daysAgo`, endDate: 'today' }],
-    dimensions: [{ name: 'date' }],
-    metrics: [{ name: 'eventCount' }],
-    dimensionFilter: {
-      filter: {
-        fieldName: 'eventName',
-        stringFilter: { matchType: 'EXACT', value: 'ball_launch' },
+  // Also fetch ball_launch and cta_click event counts per day
+  const [ballReport, ctaReport] = await Promise.all([
+    runReport(token, propId, {
+      dateRanges: [{ startDate: `${days}daysAgo`, endDate: 'today' }],
+      dimensions: [{ name: 'date' }],
+      metrics: [{ name: 'eventCount' }],
+      dimensionFilter: {
+        filter: {
+          fieldName: 'eventName',
+          stringFilter: { matchType: 'EXACT', value: 'ball_launch' },
+        },
       },
-    },
-    orderBys: [{ dimension: { dimensionName: 'date' } }],
-    limit: days + 1,
-  });
+      orderBys: [{ dimension: { dimensionName: 'date' } }],
+      limit: days + 1,
+    }),
+    runReport(token, propId, {
+      dateRanges: [{ startDate: `${days}daysAgo`, endDate: 'today' }],
+      dimensions: [{ name: 'date' }],
+      metrics: [{ name: 'eventCount' }],
+      dimensionFilter: {
+        filter: {
+          fieldName: 'eventName',
+          stringFilter: { matchType: 'EXACT', value: 'cta_click' },
+        },
+      },
+      orderBys: [{ dimension: { dimensionName: 'date' } }],
+      limit: days + 1,
+    }),
+  ]);
 
-  // Index ball interactions by date
+  // Index event counts by date
   const ballByDate = {};
   (ballReport.rows || []).forEach((row) => {
     ballByDate[row.dimensionValues[0].value] = parseInt(row.metricValues[0].value, 10);
+  });
+  const ctaByDate = {};
+  (ctaReport.rows || []).forEach((row) => {
+    ctaByDate[row.dimensionValues[0].value] = parseInt(row.metricValues[0].value, 10);
   });
 
   return (report.rows || []).map((row) => {
@@ -231,6 +250,7 @@ async function fetchTimeSeries(token, propId, days) {
       avgDuration: Math.round(parseFloat(row.metricValues[2].value)),
       bounceRate: Math.round(parseFloat(row.metricValues[3].value) * 100),
       ballInteractions: ballByDate[dateStr] || 0,
+      ctaClicks: ctaByDate[dateStr] || 0,
     };
   });
 }

--- a/src/analytics/data.js
+++ b/src/analytics/data.js
@@ -75,6 +75,7 @@ export function generateTimeSeriesData(days = 90) {
 
     const visitors = Math.round(Math.max(5, raw));
     const avgPagesPerVisit = 1.8 + rand() * 1.4;
+    const ballInteractions = Math.round(visitors * (0.4 + rand() * 0.3));
 
     data.push({
       date: date.toISOString().split('T')[0],
@@ -83,7 +84,8 @@ export function generateTimeSeriesData(days = 90) {
       pageviews: Math.round(visitors * avgPagesPerVisit),
       avgDuration: Math.round(35 + rand() * 200),
       bounceRate: Math.round(25 + rand() * 40),
-      ballInteractions: Math.round(visitors * (0.4 + rand() * 0.3)),
+      ballInteractions,
+      ctaClicks: Math.round(ballInteractions * (0.08 + rand() * 0.07)),
     });
   }
   return data;


### PR DESCRIPTION
The "Traffic Over Time" chart includes a CTA Clicks metric line, but neither the worker nor mock data included ctaClicks in time series data, so the line was always flat at zero.

- Worker: fetch cta_click events per day (parallel with ball_launch)
- Mock: derive ctaClicks from ballInteractions for demo mode