### PR TITLE
Fix shot-chart goal resolution and use live ball data for Analytics V3

### DIFF
--- a/src/analytics/AnalyticsDashboardV3.jsx
+++ b/src/analytics/AnalyticsDashboardV3.jsx
@@ -571,21 +571,20 @@ function AnalyticsTab({ timeSeriesData, rangeDays, ballData, sourcesData, pagesD
 
     {/* Shot Chart */}
     <div style={{ marginBottom: 20 }}>
-      <ShotChart liveData={BALL_ENGAGEMENT} sessionData={(() => {
+      <ShotChart liveData={ballData} sessionData={(() => {
         try {
           const bridge = JSON.parse(localStorage.getItem('__dadatadad_bridge') || 'null');
           const impacts = JSON.parse(localStorage.getItem('__dadatadad_impacts') || '[]');
           if (!bridge) return undefined;
-          // Build a ballStats Map from impact data
-          // Note: imp.isGoal is always false (Goal bodies lack .category in physics).
-          // Scoring actually happens on Menu bodies, so hitType==='menu' is the score indicator.
+          // Build a ballStats Map from per-shot impact records.
+          // A shot is marked as score once it resolves via ball:scored.
           const ballStats = new Map();
           if (Array.isArray(impacts)) {
             impacts.forEach(imp => {
               if (!imp.ballId) return;
               const existing = ballStats.get(imp.ballId) || { launches: 0, scores: 0 };
               existing.launches++;
-              if (imp.hitType === 'menu') existing.scores++;
+              if (imp.isGoal || imp.hitType === 'menu') existing.scores++;
               ballStats.set(imp.ballId, existing);
             });
           }

--- a/src/analytics/ShotChart.jsx
+++ b/src/analytics/ShotChart.jsx
@@ -46,14 +46,14 @@ function generateDots(balls, seed = 7, impacts) {
   if (impacts && impacts.length > 0) {
     const dots = [];
     impacts.forEach(imp => {
-      if (!imp.ballId || !imp.x || !imp.y) return;
+      if (!imp.ballId || imp.x == null || imp.y == null) return;
       // Map normalized coords (0-1) to SVG left zone (x: 20-320, y: 50-370)
       const svgX = 20 + imp.x * 300;
       const svgY = 50 + imp.y * 320;
       const ball = balls.find(b => b.id === imp.ballId);
       dots.push({
         x: svgX, y: svgY,
-        type: imp.hitType === 'menu' ? 'score' : 'miss',
+        type: imp.isGoal || imp.hitType === 'menu' ? 'score' : 'miss',
         ballId: imp.ballId,
         color: ball?.color || '#888',
         category: ball?.category || imp.ballCategory || '',

--- a/src/game/Game.js
+++ b/src/game/Game.js
@@ -243,6 +243,7 @@ export default class Game {
           category: ball.category,
           ballLaunches: ball.launchCount,
           ballMakes: ball.makes,
+          shotNumber: this.totalShots,
         });
       }
 
@@ -419,6 +420,7 @@ export default class Game {
             category: ball.category,
             ballLaunches: ball.launchCount,
             ballMakes: ball.makes,
+            shotNumber: this.totalShots,
           });
         }
       }
@@ -1311,5 +1313,4 @@ export default class Game {
     document.documentElement.style.setProperty('--ball-bottom', `${ballBottomY}px`);
   }
 }
-
 

--- a/src/game/ga4.js
+++ b/src/game/ga4.js
@@ -48,7 +48,25 @@ const impactStore = {
   },
 
   add(record) {
-    this._data.push(record);
+    if (!record || typeof record !== 'object') return;
+    const shotNumber = typeof record.shotNumber === 'number' ? record.shotNumber : null;
+
+    // Ensure one impact record per shot: later updates (e.g., score resolution)
+    // replace the initial first-contact snapshot for that same shot.
+    if (shotNumber != null) {
+      const idx = this._data.findIndex((r) => r && r.shotNumber === shotNumber);
+      if (idx >= 0) {
+        const prev = this._data[idx];
+        const merged = { ...prev, ...record };
+        // Preserve first-impact coordinates if a later update omits them.
+        ['x', 'y', 'px', 'py', 'vpWidth', 'vpHeight'].forEach((k) => {
+          if (record[k] == null && prev[k] != null) merged[k] = prev[k];
+        });
+        this._data[idx] = merged;
+      } else this._data.push(record);
+    } else {
+      this._data.push(record);
+    }
     // Cap stored records to prevent localStorage bloat
     if (this._data.length > MAX_IMPACTS) {
       this._data = this._data.slice(-MAX_IMPACTS);
@@ -147,6 +165,21 @@ function track(eventName, params = {}) {
   gtag('event', eventName, params);
 }
 
+function nameToBallId(name) {
+  const map = {
+    'Josh Merritt': 'aboutMe',
+    'Microsoft Power BI': 'powerBIMetrics',
+    'The Wine You Drink': 'thewineyoudrink',
+    'Black Sheep Dart League': 'dartleague',
+    'Smart Chicken Coop': 'arduinoCoopDoor',
+    'Site Analytics': 'SiteAnalytics',
+    'Google Data Studio Streaming Dashboard': 'googleDataStudioServiceTechs',
+    'Google Data Studio': 'googleDataStudioServiceTechs',
+    'Portfolio Website': 'thisWebsite',
+  };
+  return map[name] || name;
+}
+
 export function initGA4Tracking() {
   const unsubs = [];
 
@@ -161,7 +194,7 @@ export function initGA4Tracking() {
 
   // Per-ball launch
   unsubs.push(
-    bus.on('ball:launched', ({ name, category, ballLaunches, ballMakes }) => {
+    bus.on('ball:launched', ({ name, category, ballLaunches, ballMakes, shotNumber }) => {
       track('ball_launch', {
         project_name: name,
         project_category: category,
@@ -172,12 +205,33 @@ export function initGA4Tracking() {
         accuracy: currentShots > 0 ? Math.round((currentMakes / currentShots) * 100) : 0,
       });
       bridgeStats.addShot();
+
+      // Seed a per-shot impact record that can be finalized later when
+      // the shot resolves (score popup / reset) and we know make vs miss.
+      if (typeof shotNumber === 'number') {
+        impactStore.add({
+          ballId:       nameToBallId(name),
+          ballName:     name,
+          ballCategory: category,
+          hitType:      'launch',
+          hitLabel:     'launch',
+          isGoal:       false,
+          x:            null,
+          y:            null,
+          px:           null,
+          py:           null,
+          vpWidth:      null,
+          vpHeight:     null,
+          shotNumber,
+          timestamp:    Date.now(),
+        });
+      }
     }),
   );
 
   // Per-ball score
   unsubs.push(
-    bus.on('ball:scored', ({ name, category, ballLaunches, ballMakes }) => {
+    bus.on('ball:scored', ({ name, category, ballLaunches, ballMakes, shotNumber }) => {
       track('ball_score', {
         project_name: name,
         project_category: category,
@@ -188,6 +242,26 @@ export function initGA4Tracking() {
         accuracy: currentShots > 0 ? Math.round((currentMakes / currentShots) * 100) : 0,
       });
       bridgeStats.addMake();
+
+      // Finalize this shot as a make after score has been confirmed.
+      if (typeof shotNumber === 'number') {
+        impactStore.add({
+          ballId:       nameToBallId(name),
+          ballName:     name,
+          ballCategory: category,
+          hitType:      'menu',
+          hitLabel:     'Menu_final',
+          isGoal:       true,
+          x:            null,
+          y:            null,
+          px:           null,
+          py:           null,
+          vpWidth:      null,
+          vpHeight:     null,
+          shotNumber,
+          timestamp:    Date.now(),
+        });
+      }
     }),
   );
 
@@ -242,7 +316,9 @@ export function initGA4Tracking() {
   // First-impact tracking
   unsubs.push(
     bus.on('impact:first', (data) => {
-      impactStore.add(data);
+      // Keep coordinates from first contact, but don't trust first-contact
+      // goal classification until shot resolution updates it.
+      impactStore.add({ ...data, isGoal: false });
       track('ball_impact', {
         ball_name:     data.ballName,
         ball_category: data.ballCategory,


### PR DESCRIPTION
### Motivation
- Session shot dots were being classified at first contact which sometimes marked eventual makes as misses, so shot outcome must be finalized after the shot resolves. 
- The V3 shot-chart all-time view used a static fallback instead of the dashboard's live `ballData`, producing stale/inconsistent patterns versus other metrics.

### Description
- Propagate a per-shot `shotNumber` from game events by adding `shotNumber` to `ball:launched` and `ball:scored` emissions so each shot can be tracked and updated. (`src/game/Game.js`)
- Change the local impact bridge to dedupe/merge impact records by `shotNumber`, preserve first-impact coordinates, and allow later updates to mark a shot as a make; also add a small `nameToBallId` helper for seeded launch records. (`src/game/ga4.js`)
- Seed a per-shot launch record when `ball:launched` fires and finalize that record as a make when `ball:scored` fires so the impact store reflects resolved outcomes. (`src/game/ga4.js`)
- Prefer finalized `isGoal` when classifying score dots and fix the coordinate guard so valid `0` coordinates are kept, while retaining `hitType === 'menu'` compatibility. (`src/analytics/ShotChart.jsx`)
- Wire the shot-chart all-time `liveData` to the dashboard's `ballData` feed (instead of the static `BALL_ENGAGEMENT`) so all-time visuals use the same live GA4-derived events as other charts. (`src/analytics/AnalyticsDashboardV3.jsx`)

### Testing
- Ran `npm run build` and the production build completed successfully.
- Started the dev server (`vite`) and verified the app serves without errors (dev server ready). 
- Captured a Playwright screenshot of `/analytics-v3.html` to validate the shot chart rendering and data flow (screenshot saved during the run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b43397dfe08322bb9062ef60bcc107)